### PR TITLE
Fixes broken html pointing to the new website

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -23,20 +23,18 @@ acknowledgements: ""
     </span></center>
   </div>
 </div>
-
+<br>
 <hr>
 
-<h2>New ViGIL Session!</h2>
-    <p>
-https://vigilworkshop.github.io/
-    </p>
-<!-- <div class="row" id="intro"> -->
-  <!-- <div class="col-md-12"> -->
-    <!-- <img src="{{ "/static/img/splash.png" | prepend:site.baseurl }}"> -->
-    <!-- <p> Image credit: [2, 28, 12, 11, 15-21, 26]</p> -->
-  <!-- </div> -->
-<!-- </div> -->
+<div class="row">
+  <div class="col-xs-12">
+    <center>
+      <h2>New ViGIL Session: <a href="https://vigilworkshop.github.io/">vigilworkshop.github.io</a></h2>
+    </center>
+  </div>
+</div>
 
+<hr>
 <br>
 <div class="row" id="intro">
   <div class="col-xs-12">


### PR DESCRIPTION
https://nips2018vigil.github.io currently looks ~broken:


![Screen Shot 2019-10-15 at 12 06 58 AM](https://user-images.githubusercontent.com/1156489/66799587-c31baf80-eedf-11e9-888d-71c5e4801e73.png)

Updates this to:


![Screen Shot 2019-10-15 at 12 07 40 AM](https://user-images.githubusercontent.com/1156489/66799603-d2026200-eedf-11e9-8b87-ad95ba0a0b97.png)


